### PR TITLE
Add mod description below header in mod options

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,7 @@
+root = true
+
+[*.lua]
+end_of_line = lf
+insert_final_newline = true
+indent_style = space
+indent_size = 2

--- a/dmf/scripts/mods/dmf/modules/core/options.lua
+++ b/dmf/scripts/mods/dmf/modules/core/options.lua
@@ -46,7 +46,7 @@ local function initialize_header_data(mod, data)
   new_data.index             = data.index
   new_data.mod_name          = mod:get_name()
   new_data.readable_mod_name = mod:get_readable_name()
-  new_data.tooltip           = mod:get_description()
+  new_data.description       = mod:get_description()
   new_data.is_togglable      = mod:get_internal_data("is_togglable") and not mod:get_internal_data("is_mutator")
   new_data.is_collapsed      = dmf:get("options_menu_collapsed_mods")[mod:get_name()]
 

--- a/dmf/scripts/mods/dmf/modules/core/options.lua
+++ b/dmf/scripts/mods/dmf/modules/core/options.lua
@@ -518,7 +518,7 @@ local function initialize_mod_options_widgets_data(mod, widgets_data, localize)
   -- Before starting widgets data initialization, clear this table. It's used to detect if 2 widgets
   -- defined the same setting_id.
   _defined_mod_settings = {}
-  
+
   -- Initialize widgets' data.
   for _, widget_data in ipairs(_unfolded_raw_widgets_data) do
     local initialized_widget_data = initialize_widget_data(mod, widget_data, localize, collapsed_widgets)

--- a/dmf/scripts/mods/dmf/modules/ui/options/mod_options.lua
+++ b/dmf/scripts/mods/dmf/modules/ui/options/mod_options.lua
@@ -35,6 +35,23 @@ local create_header_template = function (self, params)
 end
 _type_template_map["header"] = create_header_template
 
+-- ##########################
+-- ###### Description #######
+-- ##########################
+
+-- Create description template
+local create_description_template = function (self, params)
+
+  local template = {
+    category = params.category,
+    group_name = params.mod_name,
+    display_name = params.description,
+    widget_type = "description",
+    after = params.after
+  }
+  return template
+end
+_type_template_map["description"] = create_description_template
 
 -- ###########################
 -- ###### Percent Slider #####
@@ -328,7 +345,7 @@ local function create_option_template(self, widget_data, category_name, index_of
     template.custom = true
     template.category = category_name
     template.after = template.after and template.after + index_offset or nil
-    
+
     return template
   end
 end
@@ -351,11 +368,29 @@ dmf.create_mod_options_settings = function (self, options_templates)
     local category = create_mod_category(self, categories, mod_data[1])
 
     local index_offset = 0
-    
+
     -- Create the category header
     local template = create_option_template(self, mod_data[1], category.display_name, index_offset)
     if template then
       settings[#settings + 1] = template
+    end
+
+    -- Create the mod description
+    if mod_data[1].tooltip then
+      local desc_widget_data = {
+        mod_name = mod_data[1].mod_name,
+        description = mod_data[1].tooltip,
+        category = category.display_name,
+        display_name = category.display_name,
+        after = #settings,
+        type = "description"
+      }
+      local desc_template = create_option_template(self, desc_widget_data, category.display_name, index_offset)
+
+      if desc_template then
+        settings[#settings + 1] = desc_template
+        index_offset = index_offset + 1
+      end
     end
 
     -- Create a top-level toggle option if the mod is togglable
@@ -383,7 +418,7 @@ dmf.create_mod_options_settings = function (self, options_templates)
         template.custom = true
         template.category = category.display_name
         template.after = template.after + index_offset
-        
+
         settings[#settings + 1] = template
       end
     end

--- a/dmf/scripts/mods/dmf/modules/ui/options/mod_options.lua
+++ b/dmf/scripts/mods/dmf/modules/ui/options/mod_options.lua
@@ -376,10 +376,10 @@ dmf.create_mod_options_settings = function (self, options_templates)
     end
 
     -- Create the mod description
-    if mod_data[1].tooltip then
+    if mod_data[1].description then
       local desc_widget_data = {
         mod_name = mod_data[1].mod_name,
-        description = mod_data[1].tooltip,
+        description = mod_data[1].description,
         category = category.display_name,
         display_name = category.display_name,
         after = #settings,


### PR DESCRIPTION
Also
 - adds editorconfig to make contributing easier and keep things consistent
 - renames tooltip to description in the header data

Just getting familiar with the codebase so let me know if there's anything wrong with this

Example:

![image](https://user-images.githubusercontent.com/1973559/211693956-5f0f43ac-51ce-43d1-8c70-e6a8e9268b68.png)
