### PR TITLE
Change file hook handler to callback function, rename to hook_require

### DIFF
--- a/dmf/scripts/mods/dmf/modules/core/hooks.lua
+++ b/dmf/scripts/mods/dmf/modules/core/hooks.lua
@@ -422,15 +422,16 @@ function DMFMod:hook_origin(obj, method, handler)
     return generic_hook(self, obj, method, handler, "hook_origin")
 end
 
--- :hook_file() allows you to hook every past and future version of a game file,
+-- :hook_require() allows you to hook every past and future version of a game file,
 --         executing a callback function on every instance.
 -- The chain of event is determined by mod load order.
-function DMFMod:hook_file(obj_str, callback_func)
+function DMFMod:hook_require(obj_str, callback_func)
 
     -- Set up the tables for the file
     local mod_name = self:get_name()
-    _file_hooks_by_file[obj_str]         = _file_hooks_by_file[obj_str] or {}
-    _file_hooks_applied_to_file[obj_str] = _file_hooks_applied_to_file[obj_str] or {[mod_name] = {}}
+    _file_hooks_by_file[obj_str]                   = _file_hooks_by_file[obj_str] or {}
+    _file_hooks_applied_to_file[obj_str]           = _file_hooks_applied_to_file[obj_str] or {}
+    _file_hooks_applied_to_file[obj_str][mod_name] = _file_hooks_applied_to_file[obj_str][mod_name] or {}
 
     -- Store file hooks by mod name to prevent duplicates per mod
     _file_hooks_by_file[obj_str][mod_name] = callback_func


### PR DESCRIPTION
This commit removes the function hook part of hook_file and turns it into a callback execution instead. Regular hooks can still be applied through the callback, but it now also allows modifying non-function values.

EDIT: hook_file is now renamed to hook_require