### PR TITLE
Let mods define a min_dmf value to catch version mismatch

### DIFF
--- a/dmf/scripts/mods/dmf/modules/dmf_mod_manager.lua
+++ b/dmf/scripts/mods/dmf/modules/dmf_mod_manager.lua
@@ -15,6 +15,7 @@ local ERRORS = {
     too_late_for_mod_creation = "[DMF Mod Manager] (new_mod) '%s': you can't create mods after vanilla mod manager " ..
                                  "finishes loading mod bundles.",
     -- dmf.initialize_mod_data:
+    mod_data_version_mismatch = "[DMF Mod Manager] (new_mod) mod options initialization: requires DMF version >= %s",
     mod_data_wrong_type = "[DMF Mod Manager] (new_mod) 'mod_data' initialization: mod_data file should return " ..
                            "table, not %s.",
     mod_options_initializing_failed = "[DMF Mod Manager] (new_mod) mod options initialization: could not initialize " ..
@@ -141,6 +142,7 @@ end
 -- #####################################################################################################################
 
 dmf = create_mod("DMF")
+dmf.version = "23.03.04"
 
 -- #####################################################################################################################
 -- ##### DMF internal functions and variables ##########################################################################
@@ -175,6 +177,12 @@ function dmf.initialize_mod_data(mod, mod_data)
       mod:error(ERRORS.REGULAR.mod_options_initializing_failed, error_message)
       return
     end
+  end
+
+  local min_dmf = mod_data.min_dmf
+  if min_dmf and dmf.version < min_dmf then
+    mod:error(ERRORS.REGULAR.mod_options_version_mismatch, min_dmf)
+    return
   end
 
   -- Textures initialization @TODO: move to a separate function


### PR DESCRIPTION
It would be nice if mod-makers had the option to define a minimum DMF version that their mod is compatible with and have DMF automatically alert players if their version is out-of-date. This particular implementation checks for a `min_dmf` value in the mod data of each mod; if it's defined, it's checked against the value of `dmf.version` before the mod initializes.

This has an obvious downside: `dmf.version` would have to be updated for each release of DMF. It would also require that the versioning convention remains consistent. Also I'm not sure where the best place is for `dmf.version` to be set, though I suspect where I have it here isn't great.