### PR TITLE
Add parameter defaults and better error messages for dump and dump_to_file

### DIFF
--- a/dmf/scripts/mods/dmf/modules/debug/table_dump.lua
+++ b/dmf/scripts/mods/dmf/modules/debug/table_dump.lua
@@ -61,14 +61,14 @@ local function table_dump(key, value, depth, max_depth)
 end
 
 DMFMod.dump = function (self, dumped_object, dumped_object_name, max_depth)
-
   if dmf.check_wrong_argument_type(self, "dump", "dumped_object_name", dumped_object_name, "string", "nil") or
-     dmf.check_wrong_argument_type(self, "dump", "max_depth", max_depth, "number")
+     dmf.check_wrong_argument_type(self, "dump", "max_depth", max_depth, "number", "nil")
   then
     return
   end
 
   local object_type = type(dumped_object)
+  max_depth = max_depth or 1
 
   if object_type ~= "table" then
     local error_message = "(dump): \"object_name\" is not a table. It's " .. object_type
@@ -83,11 +83,6 @@ DMFMod.dump = function (self, dumped_object, dumped_object_name, max_depth)
 
   if dumped_object_name then
     log_and_console_print(string.format("<%s>", dumped_object_name))
-  end
-
-  if not max_depth then
-    self:error("(dump): maximum depth is not specified")
-    return
   end
 
   local success, error_message = pcall(function()
@@ -344,13 +339,14 @@ end
 
 DMFMod.dump_to_file = function (self, dumped_object, object_name, max_depth)
   if dmf.check_wrong_argument_type(self, "dump_to_file", "object_name", object_name, "string", "nil") or
-     dmf.check_wrong_argument_type(self, "dump_to_file", "max_depth", max_depth, "number")
+     dmf.check_wrong_argument_type(self, "dump_to_file", "max_depth", max_depth, "number", "nil")
   then
     return
   end
 
   local object_type = type(dumped_object)
   object_name = object_name or "mod_dump_to_file"
+  max_depth = max_depth or 1
 
   if object_type ~= "table" then
     local error_message = "(dump_to_file): \"object_name\" is not a table. It's " .. object_type

--- a/dmf/scripts/mods/dmf/modules/debug/table_dump.lua
+++ b/dmf/scripts/mods/dmf/modules/debug/table_dump.lua
@@ -106,11 +106,6 @@ DMFMod.dump = function (self, dumped_object, dumped_object_name, max_depth)
 end
 
 
-
-
-
-
-
 local function table_dump_to_file(dumped_table, dumped_table_name, max_depth)
 
   -- #####################
@@ -348,14 +343,14 @@ end
 
 
 DMFMod.dump_to_file = function (self, dumped_object, object_name, max_depth)
-
-  if dmf.check_wrong_argument_type(self, "dump_to_file", "object_name", object_name, "string") or
+  if dmf.check_wrong_argument_type(self, "dump_to_file", "object_name", object_name, "string", "nil") or
      dmf.check_wrong_argument_type(self, "dump_to_file", "max_depth", max_depth, "number")
   then
     return
   end
 
   local object_type = type(dumped_object)
+  object_name = object_name or "mod_dump_to_file"
 
   if object_type ~= "table" then
     local error_message = "(dump_to_file): \"object_name\" is not a table. It's " .. object_type

--- a/dmf/scripts/mods/dmf/modules/debug/table_dump.lua
+++ b/dmf/scripts/mods/dmf/modules/debug/table_dump.lua
@@ -71,7 +71,11 @@ DMFMod.dump = function (self, dumped_object, dumped_object_name, max_depth)
   max_depth = max_depth or 1
 
   if object_type ~= "table" then
-    local error_message = "(dump): \"object_name\" is not a table. It's " .. object_type
+		local error_message = string.format(
+			'(dump): "%s" is not a table but of type "%s"',
+			dumped_object_name or "Dump object",
+			object_type
+		)
 
     if object_type ~= "nil" then
       error_message = error_message .. " (" .. tostring(dumped_object) .. ")"
@@ -349,7 +353,11 @@ DMFMod.dump_to_file = function (self, dumped_object, object_name, max_depth)
   max_depth = max_depth or 1
 
   if object_type ~= "table" then
-    local error_message = "(dump_to_file): \"object_name\" is not a table. It's " .. object_type
+		local error_message = string.format(
+			'(dump_to_file): "%s" is not a table but of type "%s"',
+			object_name or "Dump object",
+			object_type
+		)
 
     if object_type ~= "nil" then
       error_message = error_message .. " (" .. tostring(dumped_object) .. ")"

--- a/dmf/scripts/mods/dmf/modules/debug/table_dump.lua
+++ b/dmf/scripts/mods/dmf/modules/debug/table_dump.lua
@@ -60,8 +60,8 @@ local function table_dump(key, value, depth, max_depth)
   end
 end
 
-DMFMod.dump = function (self, dumped_object, dumped_object_name, max_depth)
-  if dmf.check_wrong_argument_type(self, "dump", "dumped_object_name", dumped_object_name, "string", "nil") or
+DMFMod.dump = function (self, dumped_object, object_name, max_depth)
+  if dmf.check_wrong_argument_type(self, "dump", "dumped_object_name", object_name, "string", "nil") or
      dmf.check_wrong_argument_type(self, "dump", "max_depth", max_depth, "number", "nil")
   then
     return
@@ -73,7 +73,7 @@ DMFMod.dump = function (self, dumped_object, dumped_object_name, max_depth)
   if object_type ~= "table" then
 		local error_message = string.format(
 			'(dump): "%s" is not a table but of type "%s"',
-			dumped_object_name or "Dump object",
+			object_name or "Dump object",
 			object_type
 		)
 
@@ -85,8 +85,8 @@ DMFMod.dump = function (self, dumped_object, dumped_object_name, max_depth)
     return
   end
 
-  if dumped_object_name then
-    log_and_console_print(string.format("<%s>", dumped_object_name))
+  if object_name then
+    log_and_console_print(string.format("<%s>", object_name))
   end
 
   local success, error_message = pcall(function()
@@ -99,8 +99,8 @@ DMFMod.dump = function (self, dumped_object, dumped_object_name, max_depth)
     self:error("(dump): %s", tostring(error_message))
   end
 
-  if dumped_object_name then
-    log_and_console_print(string.format("</%s>", dumped_object_name))
+  if object_name then
+    log_and_console_print(string.format("</%s>", object_name))
   end
 end
 


### PR DESCRIPTION
- Add parameter defaults for object name and max depth. `dumped_object_name` could always be empty with `dump`, but now defaults to "mod_dump_to_file" with `dump_to_file`. `max_depth` now defaults to 1. These shorter calls no longer error:
```lua
mod:dump(ikea_table)
mod:dump_to_file(ikea_table)
mod:dump_to_file(ikea_table, "ikea_table")
```
- "object_name" was hardcoded but now reflects `object_name`. These:
<img width="237" alt="image" src="https://user-images.githubusercontent.com/5785323/233031226-593a672d-6583-48c2-885a-d07e7e17d82e.png"><img width="246" alt="image" src="https://user-images.githubusercontent.com/5785323/233031444-b9f7b956-2fb9-4e2c-85d8-12f54d8f9818.png">
become:
<img width="247" alt="image" src="https://user-images.githubusercontent.com/5785323/233031330-0d9409aa-1159-47c0-9757-2627e1a897c7.png"><img width="256" alt="image" src="https://user-images.githubusercontent.com/5785323/233031387-ab3fce6d-83c0-4057-aa55-37cae0323d87.png">
- `dump` used `dumped_object_name` but `dump_to_file` used `object_name` so now they both use the latter for the parameter name.
