### PR TITLE
Fix being locked into restart when `require_restart` is true

### DIFF
--- a/dmf/scripts/mods/dmf/modules/ui/options/dmf_options_view.lua
+++ b/dmf/scripts/mods/dmf/modules/ui/options/dmf_options_view.lua
@@ -224,7 +224,7 @@ DMFOptionsView._restart_popup_info = function (self)
     description_text = "loc_popup_settings_require_restart_description",
     options = {
       {
-        text = "loc_confirm",
+        text = "loc_dmf_restart",
         close_on_pressed = true,
         callback = callback(function ()
           self._popup_id = nil
@@ -233,6 +233,16 @@ DMFOptionsView._restart_popup_info = function (self)
 
           Managers.ui:close_view(view_name)
         end)
+      },
+      {
+        text = "loc_dmf_restart_later",
+        close_on_pressed = true,
+        hotkey = "back",
+        callback = function ()
+          self._popup_id = nil
+
+          Managers.ui:close_view("dmf_options_view")
+        end
       }
     }
   }

--- a/dmf/scripts/mods/dmf/modules/ui/options/mod_options.lua
+++ b/dmf/scripts/mods/dmf/modules/ui/options/mod_options.lua
@@ -421,7 +421,13 @@ dmf:add_global_localize_strings({
     es = "Configuración de mods",
     ru = "Настройки модов",
     ["zh-cn"] = "模组选项",
-  }
+  },
+	loc_dmf_restart = {
+		en = "Restart",
+	},
+	loc_dmf_restart_later = {
+		en = "Understood, restart later",
+	},
 })
 
 local dmf_option_definition = {


### PR DESCRIPTION
Currently if `require_restart` is set for a mod option, players can unknowingly get locked into restarting the game. There is only a "Confirm" button and neither hitting Esc nor clicking elsewhere allows them to abort the process. You can use the Mod Options keybind to exit, but most likely won't think to try this.

This PR adds an extra button that confirms/closes the popup but does not exit the game. Hitting the back/Escape key will also close the popup without exiting.

<img width="671" alt="image" src="https://github.com/Darktide-Mod-Framework/Darktide-Mod-Framework/assets/5785323/3a8674aa-27f6-4106-ac6a-af7068b6a097">
