### PR TITLE
Add support for a text_input widget

### DIFF
--- a/dmf/scripts/mods/dmf/modules/core/options.lua
+++ b/dmf/scripts/mods/dmf/modules/core/options.lua
@@ -449,7 +449,7 @@ local function initialize_widget_data(mod, data, localize, collapsed_widgets)
   elseif data.type == "numeric" then
     return initialize_numeric_data(mod, data, localize)
   elseif data.type == "text_input" then
-    return initialize_generic_widget_data(mod, data, localize)
+    return initialize_keybind_data(mod, data, localize)
   end
   -- if data.type is incorrect, returns nil
 end

--- a/dmf/scripts/mods/dmf/modules/core/options.lua
+++ b/dmf/scripts/mods/dmf/modules/core/options.lua
@@ -448,6 +448,8 @@ local function initialize_widget_data(mod, data, localize, collapsed_widgets)
     return initialize_keybind_data(mod, data, localize)
   elseif data.type == "numeric" then
     return initialize_numeric_data(mod, data, localize)
+  elseif data.type == "text_input" then
+    return initialize_generic_widget_data(mod, data, localize)
   end
   -- if data.type is incorrect, returns nil
 end

--- a/dmf/scripts/mods/dmf/modules/ui/options/dmf_options_view.lua
+++ b/dmf/scripts/mods/dmf/modules/ui/options/dmf_options_view.lua
@@ -946,6 +946,11 @@ DMFOptionsView._update_settings_content_widgets = function (self, dt, t, input_s
       if update then
         update(self, widget, input_service, dt, t)
       end
+
+      -- Allows text_input widgets to stop typing with escape, without closing the entire mod options menu
+      if widget.content.is_writing then
+        self._selected_settings_widget = widget
+      end
     end
 
     if selected_settings_widget and self._close_selected_setting then

--- a/dmf/scripts/mods/dmf/modules/ui/options/dmf_options_view_content_blueprints.lua
+++ b/dmf/scripts/mods/dmf/modules/ui/options/dmf_options_view_content_blueprints.lua
@@ -837,7 +837,14 @@ blueprints.text_input = {
     local style = widget.style
 
     -- Set the initial text from the mod's current setting
-    content.input_text = entry.get_function and entry.get_function() or ""
+    if type(entry.default_value) == "table" then
+        entry.default_value = entry.default_value[1] or ""
+    end
+    local current_val = entry.get_function and entry.get_function() or ""
+    if type(current_val) == "table" then
+        current_val = current_val[1] or ""
+    end
+    content.input_text = current_val
     content.text = entry.display_name or Managers.localization:localize("loc_settings_option_unavailable")
     content.entry = entry
     content.hint_text = "Enter text..."

--- a/dmf/scripts/mods/dmf/modules/ui/options/dmf_options_view_content_blueprints.lua
+++ b/dmf/scripts/mods/dmf/modules/ui/options/dmf_options_view_content_blueprints.lua
@@ -837,7 +837,7 @@ blueprints.text_input = {
     local style = widget.style
 
     -- Set the initial text from the mod's current setting
-    content.input_text = ""
+    content.input_text = entry.get_function and entry.get_function() or ""
     content.text = entry.display_name or Managers.localization:localize("loc_settings_option_unavailable")
     content.entry = entry
     content.hint_text = "Enter text..."

--- a/dmf/scripts/mods/dmf/modules/ui/options/dmf_options_view_content_blueprints.lua
+++ b/dmf/scripts/mods/dmf/modules/ui/options/dmf_options_view_content_blueprints.lua
@@ -5,6 +5,7 @@ local _view_settings = dmf:io_dofile("dmf/scripts/mods/dmf/modules/ui/options/dm
 local ButtonPassTemplates = require("scripts/ui/pass_templates/button_pass_templates")
 local CheckboxPassTemplates = require("scripts/ui/pass_templates/checkbox_pass_templates")
 local DropdownPassTemplates = require("scripts/ui/pass_templates/dropdown_pass_templates")
+local TextInputPassTemplates = require("scripts/ui/pass_templates/text_input_pass_templates") 
 local InputUtils = require("scripts/managers/input/input_utils")
 local KeybindPassTemplates = require("scripts/ui/pass_templates/keybind_pass_templates")
 local SliderPassTemplates = require("scripts/ui/pass_templates/slider_pass_templates")
@@ -774,6 +775,99 @@ blueprints.keybind = {
         _last_dropdown_pressed = -1
       end
     end
+  end
+}
+
+-- Copied the colors from the checkbox for the text input label
+local text_input_label_style = table.clone(UIFontSettings.header_4)
+text_input_label_style.offset = { 30, 0, 3 }
+text_input_label_style.text_horizontal_alignment = "left"
+text_input_label_style.text_vertical_alignment = "center"
+text_input_label_style.text_color = Color.terminal_text_body(255, true)
+
+blueprints.text_input = {
+ size = { settings_grid_width, settings_value_height },
+  
+ pass_template_function = function (parent, config, size)
+    local passes = table.clone(TextInputPassTemplates.simple_input_field)
+
+    table.insert(passes, {
+        value_id = "text",
+        pass_type = "text",
+        style = text_input_label_style, 
+    })
+
+    local x_offset = settings_grid_width - settings_value_width
+
+    for i = 1, #passes do
+      local pass = passes[i]
+      local style_id = pass.style_id or pass.value_id
+
+      if style_id ~= "text" then
+        pass.style = pass.style or {}
+        
+        pass.style.offset = pass.style.offset or { 0, 0, 0 }
+        pass.style.offset[1] = pass.style.offset[1] + x_offset
+        
+        if style_id == "background" or style_id == "focused" or pass.pass_type == "hotspot" then
+          pass.style.size = { settings_value_width, settings_value_height }
+        end
+        if style_id == "baseline" then
+          pass.style.size = { settings_value_width, 2 }
+          -- We force 'top' alignment so the Y offset (62) puts it exactly 
+          -- at the bottom of our 64px tall row.
+          pass.style.vertical_alignment = "top" 
+          pass.style.offset[2] = settings_value_height - 2
+        end
+
+        if pass.pass_type == "text" or pass.pass_type == "text_input" then
+          pass.style.size = { settings_value_width - 20, settings_value_height }
+          pass.style.offset[1] = pass.style.offset[1] + 10
+          pass.style.text_horizontal_alignment = "left"
+          pass.style.text_vertical_alignment = "center"
+        end
+      end
+    end
+
+    return passes
+  end,
+
+  init = function (parent, widget, entry, callback_name, changed_callback_name)
+    local content = widget.content
+    local style = widget.style
+
+    -- Set the initial text from the mod's current setting
+    content.input_text = ""
+    content.text = entry.display_name or Managers.localization:localize("loc_settings_option_unavailable")
+    content.entry = entry
+    content.hint_text = "Enter text..."
+    
+    -- Sync changes back to the mod when the user finishes typing
+    entry.changed_callback = function (changed_value)
+      if entry.on_activated then
+        entry.on_activated(changed_value, entry)
+      end
+    end
+  end,
+  update = function (parent, widget, input_service, dt, t)
+    local content = widget.content
+    local entry = content.entry
+    local devices = entry.devices
+    if content and content.is_writing and input_service then
+        -- We only run logic if we have the service
+        local clicked_away = input_service:get("left_pressed") and not content.hotspot.is_hover
+        local pressed_escape = input_service:get("back")
+        if clicked_away or pressed_escape then
+            content.is_writing = false
+            entry.changed_callback(content.input_text)
+        end
+    end
+    
+    if content.hotspot.is_focused or content.is_writing then
+        parent.is_text_input_focused = true
+    else 
+      parent.is_text_input_focused = false
+    end 
   end
 }
 

--- a/dmf/scripts/mods/dmf/modules/ui/options/dmf_options_view_content_blueprints.lua
+++ b/dmf/scripts/mods/dmf/modules/ui/options/dmf_options_view_content_blueprints.lua
@@ -848,6 +848,9 @@ blueprints.text_input = {
     content.text = entry.display_name or Managers.localization:localize("loc_settings_option_unavailable")
     content.entry = entry
     content.hint_text = "Enter text..."
+    -- Update the mod:get() value for this widget to whatever the current input_text is. This fixes a bug
+    -- where it returns a table instead of the table string since text_input reuses keybind functionality
+    entry.on_activated(content.input_text, entry)
     
     -- Sync changes back to the mod when the user finishes typing
     entry.changed_callback = function (changed_value)

--- a/dmf/scripts/mods/dmf/modules/ui/options/dmf_options_view_definitions.lua
+++ b/dmf/scripts/mods/dmf/modules/ui/options/dmf_options_view_definitions.lua
@@ -448,6 +448,10 @@ local legend_inputs = {
     display_name = "loc_settings_menu_reset_to_default",
     on_pressed_callback = "cb_reset_category_to_default",
     visibility_function = function (parent)
+      if parent.is_text_input_focused then
+        return false
+      end
+      
       return not not parent._selected_category and parent._categories_by_display_name[parent._selected_category].can_be_reset
     end
   }

--- a/dmf/scripts/mods/dmf/modules/ui/options/mod_options.lua
+++ b/dmf/scripts/mods/dmf/modules/ui/options/mod_options.lua
@@ -346,6 +346,36 @@ local create_keybind_template = function (self, params)
 end
 _type_template_map["keybind"] = create_keybind_template
 
+-- ###########################
+-- ######### Text Input #########
+-- ###########################
+
+local create_text_input_template = function (self, params)
+  local template = {
+    after = params.parent_index,
+    category = params.category,
+    default_value = params.default_value or "",
+    display_name = params.title,
+    indentation_level = params.depth,
+    tooltip_text = params.tooltip,
+    widget_type = "text_input",
+    mod_name = params.mod_name,
+    setting_id = params.setting_id,
+  }
+  
+  template.on_activated = function(new_value)
+    get_mod(params.mod_name):set(params.setting_id, new_value, true)
+    return true
+  end
+
+  template.get_function = function()
+    return get_mod(params.mod_name):get(params.setting_id)
+  end
+
+  return template
+end
+_type_template_map["text_input"] = create_text_input_template
+
 
 -- ###########################
 -- ###### Miscellaneous ######

--- a/dmf/scripts/mods/dmf/modules/ui/options/mod_options.lua
+++ b/dmf/scripts/mods/dmf/modules/ui/options/mod_options.lua
@@ -346,9 +346,9 @@ local create_keybind_template = function (self, params)
 end
 _type_template_map["keybind"] = create_keybind_template
 
--- ###########################
+-- ##############################
 -- ######### Text Input #########
--- ###########################
+-- ##############################
 
 local create_text_input_template = function (self, params)
   local template = {
@@ -361,10 +361,15 @@ local create_text_input_template = function (self, params)
     widget_type = "text_input",
     mod_name = params.mod_name,
     setting_id = params.setting_id,
+    function_name = params.function_name
   }
   
   template.on_activated = function(new_value)
-    get_mod(params.mod_name):set(params.setting_id, new_value, true)
+    local mod = get_mod(params.mod_name)
+    mod:set(params.setting_id, new_value, true)
+    if template.function_name and mod[template.function_name] then
+      dmf.safe_call_nr(mod, {"[Text Input] function_call", template.function_name}, mod[template.function_name], true)
+    end
     return true
   end
 


### PR DESCRIPTION
This change adds support for text_widget as a widget type. Below is an image of me testing the widget in game, by printing the value in the text box whenever I press K. 

<img width="1081" height="706" alt="image" src="https://github.com/user-attachments/assets/c2f3653b-acc7-4ff4-8438-9eeea844b475" />
