### PR TITLE
Refine color slider controls and restore legacy text_input support

### DIFF
--- a/dmf/scripts/mods/dmf/modules/core/options.lua
+++ b/dmf/scripts/mods/dmf/modules/core/options.lua
@@ -614,11 +614,6 @@ end
 -- ---------------------------------------------------------------------------------------------------------------------
 
 local function initialize_widget_data(mod, data, localize, collapsed_widgets)
-  -- backward compatibility for the legacy widget type
-  if data.type == "text_input" then
-    data.type = "text"
-  end
-
   if data.type == "header" then
     return initialize_header_data(mod, data)
   elseif data.type == "group" then
@@ -637,6 +632,9 @@ local function initialize_widget_data(mod, data, localize, collapsed_widgets)
     return initialize_color_data(mod, data, localize)
   elseif data.type == "text" then
     return initialize_text_data(mod, data, localize)
+  elseif data.type == "text_input" then
+    -- The legacy widget reused keybind initialization for its stored value and callback fields.
+    return initialize_keybind_data(mod, data, localize)
   end
   -- if data.type is incorrect, returns nil
 end

--- a/dmf/scripts/mods/dmf/modules/ui/options/color/color_widget_passes.lua
+++ b/dmf/scripts/mods/dmf/modules/ui/options/color/color_widget_passes.lua
@@ -6,7 +6,6 @@ local PREVIEW_SIZE = 64
 local PREVIEW_GAP = 8
 local CHANNEL_LABEL_WIDTH = 20
 local MAX_TRACK_HEIGHT = 16
-local DRAG_SENSITIVITY = 1
 local TRACK_COLOR = Color.terminal_corner(140, true)
 local TRACK_HOVER_COLOR = Color.terminal_corner_hover(165, true)
 local HIGHLIGHT_SIZE_ADDITION = ListHeaderPassTemplates.highlight_size_addition
@@ -24,11 +23,13 @@ local function cursor_x(input_service, inverse_scale)
   return cursor[1]
 end
 
+local function track_geometry(controls_x, controls_width)
+  return controls_x + CHANNEL_LABEL_WIDTH, controls_width - CHANNEL_LABEL_WIDTH
+end
+
 local function stop_drag(content)
   content.active_color_channel = nil
   content.drag_active = nil
-  content.drag_value = nil
-  content.previous_cursor_x = nil
 end
 
 local function preview_is_highlighted(content)
@@ -36,8 +37,10 @@ local function preview_is_highlighted(content)
     or content.exclusive_focus and content.gamepad_selected_control == "preview"
 end
 
-local function create_drag_logic(channels, has_alpha)
-  return function (pass_, renderer, style_, content)
+local function create_drag_logic(channels, has_alpha, controls_x, controls_width)
+  local track_x, track_width = track_geometry(controls_x, controls_width)
+
+  return function (pass_, renderer, style_, content, position)
     local input_service = renderer.input_service
 
     if not input_service then
@@ -58,16 +61,17 @@ local function create_drag_logic(channels, has_alpha)
         local hotspot = content["color_hotspot_" .. channel.index]
 
         if hotspot.on_pressed then
-          content.active_color_channel = channel.index
+          active_channel = channel.index
+          content.active_color_channel = active_channel
           content.drag_active = true
-          content.drag_value = content.preview_color[channel.index]
-          content.previous_cursor_x = cursor_x(input_service, renderer.inverse_scale)
 
-          return
+          break
         end
       end
 
-      return
+      if not active_channel then
+        return
+      end
     end
 
     if not input_service:get("left_hold") then
@@ -77,22 +81,13 @@ local function create_drag_logic(channels, has_alpha)
     end
 
     local current_cursor_x = cursor_x(input_service, renderer.inverse_scale)
-    local cursor_delta = current_cursor_x - content.previous_cursor_x
-
-    content.previous_cursor_x = current_cursor_x
-
-    if cursor_delta == 0 then
-      return
-    end
-
-    local drag_value = math.clamp(content.drag_value + cursor_delta * DRAG_SENSITIVITY, 0, 255)
-    local component_value = math.round(drag_value)
+    local track_progress = math.clamp((current_cursor_x - position[1] - track_x) / track_width, 0, 1)
+    local component_value = math.round(track_progress * 255)
 
     if content.preview_color[active_channel] == component_value then
       return
     end
 
-    content.drag_value = drag_value
     content.preview_color[active_channel] = component_value
 
     if not has_alpha then
@@ -226,8 +221,7 @@ local function create_channel_passes(channel, channel_order, channel_count, cont
   local row_y = (height - row_height * channel_count) * 0.5 + (channel_order - 1) * row_height
   local track_height = math.min(MAX_TRACK_HEIGHT, row_height - 4)
   local track_y = row_y + (row_height - track_height) * 0.5
-  local track_x = controls_x + CHANNEL_LABEL_WIDTH
-  local track_width = controls_width - CHANNEL_LABEL_WIDTH
+  local track_x, track_width = track_geometry(controls_x, controls_width)
   local hotspot_id = "color_hotspot_" .. channel_index
   local value_id = "color_value_" .. channel_index
   local label_style = table.clone(UIFontSettings.list_button)
@@ -377,7 +371,7 @@ local function create_pass_template(width, height, settings_value_width, has_alp
 
   passes[#passes + 1] = {
     pass_type = "logic",
-    value = create_drag_logic(channels, has_alpha),
+    value = create_drag_logic(channels, has_alpha, controls_x, controls_width),
   }
 
   table.append(passes, create_preview_passes(preview_x))

--- a/dmf/scripts/mods/dmf/modules/ui/options/dmf_options_view_content_blueprints.lua
+++ b/dmf/scripts/mods/dmf/modules/ui/options/dmf_options_view_content_blueprints.lua
@@ -4,6 +4,7 @@ local dmf = get_mod("DMF")
 local _view_settings = dmf:io_dofile("dmf/scripts/mods/dmf/modules/ui/options/dmf_options_view_settings")
 local ColorWidget = dmf:io_dofile("dmf/scripts/mods/dmf/modules/ui/options/color/color_widget")
 local NumericInput = dmf:io_dofile("dmf/scripts/mods/dmf/modules/ui/options/numeric/numeric_input")
+local TextInputWidget = dmf:io_dofile("dmf/scripts/mods/dmf/modules/ui/options/text_input/text_input_widget")
 local TextWidget = dmf:io_dofile("dmf/scripts/mods/dmf/modules/ui/options/text/text_widget")
 
 local ButtonPassTemplates = require("scripts/ui/pass_templates/button_pass_templates")
@@ -1041,5 +1042,10 @@ blueprints.keybind = {
 }
 
 blueprints.text = TextWidget.create_blueprint(settings_grid_width, settings_value_width, settings_value_height)
+blueprints.text_input = TextInputWidget.create_blueprint(
+  settings_grid_width,
+  settings_value_width,
+  settings_value_height
+)
 
 return settings("DMFOptionsViewContentBlueprints", blueprints)

--- a/dmf/scripts/mods/dmf/modules/ui/options/mod_options.lua
+++ b/dmf/scripts/mods/dmf/modules/ui/options/mod_options.lua
@@ -435,6 +435,44 @@ local create_text_template = function (self, params)
 end
 _type_template_map["text"] = create_text_template
 
+-- ##############################
+-- ######### Text Input #########
+-- ##############################
+
+local create_text_input_template = function (self, params)
+  local template = {
+    after = params.parent_index,
+    category = params.category,
+    default_value = params.default_value or "",
+    display_name = params.title,
+    indentation_level = params.depth,
+    tooltip_text = params.tooltip,
+    widget_type = "text_input",
+    mod_name = params.mod_name,
+    setting_id = params.setting_id,
+    function_name = params.function_name
+  }
+
+  template.on_activated = function(new_value)
+    local mod = get_mod(params.mod_name)
+
+    mod:set(params.setting_id, new_value, true)
+
+    if template.function_name and mod[template.function_name] then
+      dmf.safe_call_nr(mod, { "[Text Input] function_call", template.function_name }, mod[template.function_name], true)
+    end
+
+    return true
+  end
+
+  template.get_function = function()
+    return get_mod(params.mod_name):get(params.setting_id)
+  end
+
+  return template
+end
+_type_template_map["text_input"] = create_text_input_template
+
 
 -- ###########################
 -- ###### Miscellaneous ######

--- a/dmf/scripts/mods/dmf/modules/ui/options/text_input/text_input_widget.lua
+++ b/dmf/scripts/mods/dmf/modules/ui/options/text_input/text_input_widget.lua
@@ -1,0 +1,110 @@
+local TextInputPassTemplates = require("scripts/ui/pass_templates/text_input_pass_templates")
+local UIFontSettings = require("scripts/managers/ui/ui_font_settings")
+
+local TextInputWidget = {}
+
+local label_style = table.clone(UIFontSettings.header_4)
+label_style.offset = { 30, 0, 3 }
+label_style.text_horizontal_alignment = "left"
+label_style.text_vertical_alignment = "center"
+label_style.text_color = Color.terminal_text_body(255, true)
+
+local function create_passes(size, value_width, value_height)
+  local passes = table.clone(TextInputPassTemplates.simple_input_field)
+
+  passes[#passes + 1] = {
+    value_id = "text",
+    pass_type = "text",
+    style = label_style,
+  }
+
+  local x_offset = size[1] - value_width
+
+  for i = 1, #passes do
+    local pass = passes[i]
+    local style_id = pass.style_id or pass.value_id
+
+    if style_id ~= "text" then
+      pass.style = pass.style or {}
+      pass.style.offset = pass.style.offset or { 0, 0, 0 }
+      pass.style.offset[1] = pass.style.offset[1] + x_offset
+
+      if style_id == "background" or style_id == "focused" or pass.pass_type == "hotspot" then
+        pass.style.size = { value_width, value_height }
+      elseif style_id == "baseline" then
+        pass.style.size = { value_width, 2 }
+        pass.style.vertical_alignment = "top"
+        pass.style.offset[2] = value_height - 2
+      end
+
+      if pass.pass_type == "text" or pass.pass_type == "text_input" then
+        pass.style.size = { value_width - 20, value_height }
+        pass.style.offset[1] = pass.style.offset[1] + 10
+        pass.style.text_horizontal_alignment = "left"
+        pass.style.text_vertical_alignment = "center"
+      end
+    end
+  end
+
+  return passes
+end
+
+TextInputWidget.create_blueprint = function (grid_width, value_width, value_height)
+  return {
+    size = { grid_width, value_height },
+    pass_template_function = function (parent_, config_, size)
+      return create_passes(size, value_width, value_height)
+    end,
+    init = function (parent_, widget, entry, callback_name_, changed_callback_name_)
+      local content = widget.content
+
+      if type(entry.default_value) == "table" then
+        entry.default_value = entry.default_value[1] or ""
+      end
+
+      local current_value = entry.get_function and entry.get_function() or ""
+
+      if type(current_value) == "table" then
+        current_value = current_value[1] or ""
+      end
+
+      content.input_text = current_value
+      content.text = entry.display_name or Managers.localization:localize("loc_settings_option_unavailable")
+      content.entry = entry
+      content.hint_text = "Enter text..."
+
+      -- text_input reuses keybind initialization, which stores its default value in a table.
+      entry.on_activated(content.input_text, entry)
+
+      entry.changed_callback = function (changed_value)
+        if entry.on_activated then
+          entry.on_activated(changed_value, entry)
+        end
+      end
+    end,
+    update = function (parent, widget, input_service)
+      local content = widget.content
+      local entry = content.entry
+
+      if content.is_writing and input_service then
+        local clicked_away = input_service:get("left_pressed") and not content.hotspot.is_hover
+        local pressed_escape = input_service:get("back")
+
+        if clicked_away or pressed_escape then
+          content.is_writing = false
+          entry.changed_callback(content.input_text)
+        end
+      end
+
+      if content.hotspot.is_focused or content.is_writing then
+        parent.is_text_input_focused = true
+      end
+
+      if content.is_writing then
+        parent._selected_settings_widget = widget
+      end
+    end,
+  }
+end
+
+return TextInputWidget


### PR DESCRIPTION
based on feedback:
- changed color sliders mouse control, they are following cursor's position, just like numeric widgets
- restored full `text_input` compatibility, modders can take their time to migrate. No bugfix is applied to legacy implementation

most of the code changes are just the old text_input implementation